### PR TITLE
Fix error and add "all" option

### DIFF
--- a/make_diagram.py
+++ b/make_diagram.py
@@ -2,8 +2,11 @@ import argparse
 import pandas as pd
 import matplotlib.pyplot as plt
 import datetime
-import matplotlib.dates as mdates
 
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+import datetime
 
 def select_columns(data):
     print("Available columns:")
@@ -11,10 +14,15 @@ def select_columns(data):
         print(f"{index}. {column}")
 
     selected_columns = input(
-        "Enter the column numbers you want to display, separated by commas (e.g., 1,2,3): ")
-    selected_indices = [
-        int(x) - 1 for x in selected_columns.split(',')]  # Adjust indices
-    return data.iloc[:, selected_indices]
+        "Enter the column numbers you want to display, separated by commas (e.g., 1,2,3) or type 'all' to select all columns: ")
+
+    if selected_columns.strip().lower() == 'all':
+        return data
+    else:
+        selected_indices = [
+            int(x) - 1 for x in selected_columns.split(',')]  # Adjust indices
+        return data.iloc[:, selected_indices]
+
 
 
 if __name__ == "__main__":
@@ -60,15 +68,58 @@ if __name__ == "__main__":
     else:
         plt.title(f'CSV Data Visualization for {start_date} - {end_date}')
 
-    # Customize x-axis ticks and labels
-    ax.xaxis.set_major_locator(mdates.HourLocator(
-        interval=1))  # Set major ticks every hour
-    ax.xaxis.set_minor_locator(mdates.MinuteLocator(
-        interval=30))  # Set minor ticks every 30 minutes
-    ax.xaxis.set_major_formatter(mdates.DateFormatter(
-        '%#d/%#m %H:%M'))  # Format major ticks for Windows
+    plt.grid(True)
 
-    plt.xticks(rotation=45)
+    # Set the legend position to the best location based on the plotted data
+    ax.legend(loc='best')
+
+    plt.show()
+
+
+
+if __name__ == "__main__":
+
+    # 1. Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Visualize data from a CSV file")
+    parser.add_argument("-f", "--file_path",
+                        help="Path to the CSV file", default=None)
+    args = parser.parse_args()
+
+    # If no file path is provided as an argument, ask for the file name manually
+    if args.file_path is None:
+        file_name = input("Enter the name of the CSV file: ")
+    else:
+        file_name = args.file_path
+
+    # 2. Parse the file
+    data = pd.read_csv(args.file_path)
+
+    # 3. Convert Unix timestamp to a more user-friendly format
+    data['Time'] = data['Time'].apply(
+        lambda x: datetime.datetime.fromtimestamp(int(x)))
+
+    # 4. Set the date as index
+    data.set_index('Time', inplace=True)
+
+    # 6. Select columns to display
+    data = select_columns(data)
+
+    # 5. Create a diagram using the first column (date) as the x axis and selected columns on the y axis
+    fig, ax = plt.subplots(figsize=(10, 5))
+    data.plot(ax=ax)
+    plt.xlabel('Time')
+    plt.ylabel('Values')
+
+    # Change the date format in the title
+    start_date = data.index[0].strftime('%Y/%m/%d')
+    end_date = data.index[-1].strftime('%Y/%m/%d')
+
+    if start_date == end_date:
+        plt.title(f'CSV Data Visualization for {start_date}')
+    else:
+        plt.title(f'CSV Data Visualization for {start_date} - {end_date}')
+
     plt.grid(True)
 
     # Set the legend position to the best location based on the plotted data

--- a/make_diagram.py
+++ b/make_diagram.py
@@ -18,60 +18,6 @@ def select_columns(data):
             int(x) - 1 for x in selected_columns.split(',')]  # Adjust indices
         return data.iloc[:, selected_indices]
 
-
-
-if __name__ == "__main__":
-
-    # 1. Parse command line arguments
-    parser = argparse.ArgumentParser(
-        description="Visualize data from a CSV file")
-    parser.add_argument("-f", "--file_path",
-                        help="Path to the CSV file", default=None)
-    args = parser.parse_args()
-
-    # If no file path is provided as an argument, ask for the file name manually
-    if args.file_path is None:
-        file_name = input("Enter the name of the CSV file: ")
-    else:
-        file_name = args.file_path
-
-    # 2. Parse the file
-    data = pd.read_csv(args.file_path)
-
-    # 3. Convert Unix timestamp to a more user-friendly format
-    data['Time'] = data['Time'].apply(
-        lambda x: datetime.datetime.fromtimestamp(int(x)))
-
-    # 4. Set the date as index
-    data.set_index('Time', inplace=True)
-
-    # 6. Select columns to display
-    data = select_columns(data)
-
-    # 5. Create a diagram using the first column (date) as the x axis and selected columns on the y axis
-    fig, ax = plt.subplots(figsize=(10, 5))
-    data.plot(ax=ax)
-    plt.xlabel('Time')
-    plt.ylabel('Values')
-
-    # Change the date format in the title
-    start_date = data.index[0].strftime('%Y/%m/%d')
-    end_date = data.index[-1].strftime('%Y/%m/%d')
-
-    if start_date == end_date:
-        plt.title(f'CSV Data Visualization for {start_date}')
-    else:
-        plt.title(f'CSV Data Visualization for {start_date} - {end_date}')
-
-    plt.grid(True)
-
-    # Set the legend position to the best location based on the plotted data
-    ax.legend(loc='best')
-
-    plt.show()
-
-
-
 if __name__ == "__main__":
 
     # 1. Parse command line arguments

--- a/make_diagram.py
+++ b/make_diagram.py
@@ -3,11 +3,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import datetime
 
-import argparse
-import pandas as pd
-import matplotlib.pyplot as plt
-import datetime
-
 def select_columns(data):
     print("Available columns:")
     for index, column in enumerate(data.columns, start=1):


### PR DESCRIPTION
For some reason custom x-axis ticks and labels were causing int overflow and I was unable to fix it without removing this feature.

Also added the option to say "all" instead of specifying all columns like 1,2,3,4,5,6,7,8 every time.